### PR TITLE
Update `MPFR` to Version `4.1.0`

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -13,7 +13,7 @@ source:
   - patches/corei5.patch
 
 build:
-  number: 1
+  number: 0
   skip: True  # [win and vc<14]
   run_exports:
     - {{ pin_subpackage("mpfr") }}
@@ -46,7 +46,9 @@ about:
   home: http://www.mpfr.org/
   license: LGPL-3.0-only
   license_file: {{ SRC_DIR }}/COPYING.LESSER
+  license_family: LGPL
   summary: The MPFR library is a C library for multiple-precision floating-point computations with correct rounding.
+  dev_url: https://gitlab.inria.fr/mpfr/mpfr
 
 extra:
   recipe-maintainers:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,4 +1,4 @@
-{% set version = "4.0.2" %}
+{% set version = "4.1.0" %}
 
 package:
   name: mpfr
@@ -7,7 +7,7 @@ package:
 source:
   fn: mpfr-{{ version }}.tar.bz2
   url: http://ftp.gnu.org/gnu/mpfr/mpfr-{{ version }}.tar.gz
-  sha256: ae26cace63a498f07047a784cd3b0e4d010b44d2b193bab82af693de57a19a78
+  sha256: 3127fe813218f3a1f0adf4e8899de23df33b4cf4b4b3831a5314f78e65ffa2d6
   patches:
   - patches/build-vc14.patch
   - patches/corei5.patch


### PR DESCRIPTION

  `mpfr` version `4.1.0`
1. check the upstream
    https://gitlab.inria.fr/mpfr/mpfr/-/tree/4.1.0

2. check the pinnings
    https://gitlab.inria.fr/mpfr/mpfr/-/blob/4.1.0/mpfr.pc.in
    https://gitlab.inria.fr/mpfr/mpfr/-/blob/4.1.0/configure.ac
    https://gitlab.inria.fr/mpfr/mpfr/-/blob/4.1.0/codespell.exclude
    https://gitlab.inria.fr/mpfr/mpfr/-/blob/4.1.0/autogen.sh
    https://gitlab.inria.fr/mpfr/mpfr/-/blob/4.1.0/acinclude.m4
    https://gitlab.inria.fr/mpfr/mpfr/-/blob/4.1.0/INSTALL

3. check the changelogs
    https://gitlab.inria.fr/mpfr/mpfr/-/blob/4.1.0/ChangeLog?expanded=true&viewer=simple

4. additional research
    https://github.com/conda-forge/mpfr-feedstock/issues

    There were no open issues mentioned at the time of the review

5. verify dev_url
    https://gitlab.inria.fr/mpfr/mpfr

6. verify doc_url
    doc_url: https://www.mpfr.org/mpfr-current/#doc

7. license is spdx compliant
    https://spdx.org/licenses/LGPL-3.0-only.html
8. license family
    https://spdx.org/licenses/LGPL-3.0.html
9. verify the build number
    the build number is set to zero
10. verify setuptools
    setuptools was not mentioned in the upstream
11. verify wheel
    wheels was not mentioned in the upstream
12. pip in the test section
    pip was not mentioned in the upstream
13. veriy the test section
14. additional tests

There were no errors during the building process

Based on the research findings and the test results we can conclude
that it is safe to update `mpfr` to version `4.1.0`
