### PR TITLE
mpfr 4.1.0

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -22,10 +22,11 @@ build:
 
 requirements:
   build:
+    - {{ compiler('c') }}
+    - gnuconfig       # [unix]
     - libtool         # [unix]
     - m4              # [unix]
     - make            # [unix]
-    - {{ compiler('c') }}
     - patch       # [not win]
     - m2-patch    # [win]
   host:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,4 +1,4 @@
-{% set version = "4.0.2" %}
+{% set version = "4.1.0" %}
 
 package:
   name: mpfr
@@ -7,7 +7,7 @@ package:
 source:
   fn: mpfr-{{ version }}.tar.bz2
   url: http://ftp.gnu.org/gnu/mpfr/mpfr-{{ version }}.tar.gz
-  sha256: ae26cace63a498f07047a784cd3b0e4d010b44d2b193bab82af693de57a19a78
+  sha256: 3127fe813218f3a1f0adf4e8899de23df33b4cf4b4b3831a5314f78e65ffa2d6
   patches:
   - patches/build-vc14.patch
   - patches/corei5.patch

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -13,17 +13,17 @@ source:
   - patches/corei5.patch
 
 build:
-  number: 1
+  number: 0
   skip: True  # [win and vc<14]
   run_exports:
     - {{ pin_subpackage("mpfr") }}
 
 requirements:
   build:
+    - {{ compiler('c') }}
     - libtool         # [unix]
     - m4              # [unix]
     - make            # [unix]
-    - {{ compiler('c') }}
   host:
     - gmp             # [unix]
     - mpir            # [win]
@@ -43,10 +43,12 @@ test:
     - test -f ${PREFIX}/lib/libmpfr${SHLIB_EXT}                # [unix]
 
 about:
-  home: http://www.mpfr.org/
-  license: LGPL-3.0-only
+  home: https://www.mpfr.org/
+  license: LGPL-3.0-or-later
   license_file: {{ SRC_DIR }}/COPYING.LESSER
   summary: The MPFR library is a C library for multiple-precision floating-point computations with correct rounding.
+  doc_url: https://mpfr.loria.fr/mpfr-current/mpfr.html
+  dev_url: https://gitlab.inria.fr/mpfr/mpfr
 
 extra:
   recipe-maintainers:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -17,6 +17,8 @@ build:
   skip: True  # [win and vc<14]
   run_exports:
     - {{ pin_subpackage("mpfr") }}
+  missing_dso_whitelist:
+    - $RPATH/ld64.so.1  # [linux and s390x]
 
 requirements:
   build:


### PR DESCRIPTION
Update mpfr to 4.1.0

Changelog: **no breaking changes** and it's compatible with 4.0.* https://mpfr.loria.fr/mpfr-current/#changes
License: https://gitlab.inria.fr/mpfr/mpfr/-/blob/master/COPYING.LESSER and https://gitlab.inria.fr/mpfr/mpfr/-/blob/master/COPYING
Installation: https://gitlab.inria.fr/mpfr/mpfr/-/blob/master/INSTALL

Actions:
1. Reset build number
2. Add `missing_dso_whitelist: $RPATH/ld64.so.1` for `s390x`
3. Update home url with HTTPS
4. Update license name
5. Add dev and doc urls